### PR TITLE
feat: Update Shield component with account verification and auth improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ AWS Shield is a managed DDoS (Distributed Denial of Service) protection service 
 
 This component configures **AWS Shield Advanced** protection for specific resources.
 
+## Component Features
+
+- **Multi-Resource Protection**: Protects ALBs, CloudFront Distributions, Elastic IPs, and Route53 Hosted Zones
+- **Auto-Discovery**: Automatically discovers ALB names from EKS ALB controller via remote state
+- **Global and Regional**: Supports both global (Route53, CloudFront) and regional (ALB, EIP) resource protection
+- **Account Verification**: Optional safety check that validates Terraform is running in the correct AWS account
+- **Flexible Account Map**: Supports both remote-state account-map lookups (default) and static account map variables
+
 ## Prerequisites
 
 This component requires that the account where it is being provisioned has been
@@ -306,18 +314,20 @@ aws shield describe-subscription
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0.0 |
+| <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_account_map"></a> [account\_map](#module\_account\_map) | cloudposse/stack-config/yaml//modules/remote-state | 1.8.0 |
 | <a name="module_alb"></a> [alb](#module\_alb) | cloudposse/stack-config/yaml//modules/remote-state | 1.8.0 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
@@ -330,6 +340,7 @@ aws shield describe-subscription
 | [aws_shield_protection.cloudfront_shield_protection](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/shield_protection) | resource |
 | [aws_shield_protection.eip_shield_protection](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/shield_protection) | resource |
 | [aws_shield_protection.route53_zone_protection](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/shield_protection) | resource |
+| [terraform_data.account_verification](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [aws_alb.alb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/alb) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_cloudfront_distribution.cloudfront_distribution](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudfront_distribution) | data source |
@@ -341,6 +352,11 @@ aws shield describe-subscription
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_account_map"></a> [account\_map](#input\_account\_map) | Static account map configuration. Only used when `account_map_enabled` is `false`.<br/>Map keys use `tenant-stage` format (e.g., `core-security`, `core-audit`, `plat-prod`). | <pre>object({<br/>    full_account_map              = map(string)<br/>    audit_account_account_name    = optional(string, "")<br/>    root_account_account_name     = optional(string, "")<br/>    identity_account_account_name = optional(string, "")<br/>    aws_partition                 = optional(string, "aws")<br/>    iam_role_arn_templates        = optional(map(string), {})<br/>  })</pre> | <pre>{<br/>  "audit_account_account_name": "",<br/>  "aws_partition": "aws",<br/>  "full_account_map": {},<br/>  "iam_role_arn_templates": {},<br/>  "identity_account_account_name": "",<br/>  "root_account_account_name": ""<br/>}</pre> | no |
+| <a name="input_account_map_component_name"></a> [account\_map\_component\_name](#input\_account\_map\_component\_name) | The name of the account-map component | `string` | `"account-map"` | no |
+| <a name="input_account_map_enabled"></a> [account\_map\_enabled](#input\_account\_map\_enabled) | Enable the account map component. When true (default), the component fetches account mappings from the<br/>`account-map` component via remote state. When false, the component uses the static `account_map` variable instead. | `bool` | `true` | no |
+| <a name="input_account_map_tenant"></a> [account\_map\_tenant](#input\_account\_map\_tenant) | The tenant where the `account_map` component required by remote-state is deployed | `string` | `"core"` | no |
+| <a name="input_account_verification_enabled"></a> [account\_verification\_enabled](#input\_account\_verification\_enabled) | Enable account verification. When true (default), the component verifies that Terraform is executing<br/>in the correct AWS account by comparing the current account ID against the expected account from the<br/>account\_map based on the component's tenant-stage context. | `bool` | `true` | no |
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br/>This is for some rare cases where resources want additional configuration of tags<br/>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
 | <a name="input_alb_names"></a> [alb\_names](#input\_alb\_names) | list of ALB names which will be protected with AWS Shield Advanced | `list(string)` | `[]` | no |
 | <a name="input_alb_protection_enabled"></a> [alb\_protection\_enabled](#input\_alb\_protection\_enabled) | Enable ALB protection. By default, ALB names are read from the EKS cluster ALB control group | `bool` | `false` | no |
@@ -352,15 +368,20 @@ aws shield describe-subscription
 | <a name="input_eips"></a> [eips](#input\_eips) | List of Elastic IPs which will be protected with AWS Shield Advanced | `list(string)` | `[]` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
+| <a name="input_global_environment"></a> [global\_environment](#input\_global\_environment) | Global environment name | `string` | `"gbl"` | no |
 | <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br/>Set to `0` for unlimited length.<br/>Set to `null` for keep the existing setting, which defaults to `0`.<br/>Does not affect `id_full`. | `number` | `null` | no |
+| <a name="input_import_profile_name"></a> [import\_profile\_name](#input\_import\_profile\_name) | AWS Profile name to use when importing a resource | `string` | `null` | no |
+| <a name="input_import_role_arn"></a> [import\_role\_arn](#input\_import\_role\_arn) | IAM Role ARN to use when importing a resource | `string` | `null` | no |
 | <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | Controls the letter case of the `tags` keys (label names) for tags generated by this module.<br/>Does not affect keys of tags passed in via the `tags` input.<br/>Possible values: `lower`, `title`, `upper`.<br/>Default value: `title`. | `string` | `null` | no |
 | <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The order in which the labels (ID elements) appear in the `id`.<br/>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br/>You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present. | `list(string)` | `null` | no |
 | <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | Controls the letter case of ID elements (labels) as included in `id`,<br/>set as tag values, and output by this module individually.<br/>Does not affect values of tags passed in via the `tags` input.<br/>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br/>Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.<br/>Default value: `lower`. | `string` | `null` | no |
 | <a name="input_labels_as_tags"></a> [labels\_as\_tags](#input\_labels\_as\_tags) | Set of labels (ID elements) to include as tags in the `tags` output.<br/>Default is to include all labels.<br/>Tags with empty values will not be included in the `tags` output.<br/>Set to `[]` to suppress all generated tags.<br/>**Notes:**<br/>  The value of the `name` tag, if included, will be the `id`, not the `name`.<br/>  Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be<br/>  changed in later chained modules. Attempts to change it will be silently ignored. | `set(string)` | <pre>[<br/>  "default"<br/>]</pre> | no |
 | <a name="input_name"></a> [name](#input\_name) | ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.<br/>This is the only ID element not also included as a `tag`.<br/>The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input. | `string` | `null` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique | `string` | `null` | no |
+| <a name="input_privileged"></a> [privileged](#input\_privileged) | true if the default provider already has access to the backend | `bool` | `false` | no |
 | <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br/>Characters matching the regex will be removed from the ID elements.<br/>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS Region | `string` | n/a | yes |
+| <a name="input_root_account_stage"></a> [root\_account\_stage](#input\_root\_account\_stage) | The stage name for the Organization root (management) account. This is used to lookup account IDs from account names<br/>using the `account-map` component. | `string` | `"root"` | no |
 | <a name="input_route53_zone_names"></a> [route53\_zone\_names](#input\_route53\_zone\_names) | List of Route53 Hosted Zone names which will be protected with AWS Shield Advanced | `list(string)` | `[]` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br/>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ This component configures **AWS Shield Advanced** protection for specific resour
 - **Auto-Discovery**: Automatically discovers ALB names from EKS ALB controller via remote state
 - **Global and Regional**: Supports both global (Route53, CloudFront) and regional (ALB, EIP) resource protection
 - **Account Verification**: Optional safety check that validates Terraform is running in the correct AWS account
-- **Flexible Account Map**: Supports both remote-state account-map lookups (default) and static account map variables
+- **Flexible Account Map**: Supports both remote-state account-map lookups and static account map variables (default)
 
 ## Prerequisites
 
@@ -329,7 +329,6 @@ aws shield describe-subscription
 |------|--------|---------|
 | <a name="module_account_map"></a> [account\_map](#module\_account\_map) | cloudposse/stack-config/yaml//modules/remote-state | 1.8.0 |
 | <a name="module_alb"></a> [alb](#module\_alb) | cloudposse/stack-config/yaml//modules/remote-state | 1.8.0 |
-| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
 ## Resources
@@ -354,7 +353,7 @@ aws shield describe-subscription
 |------|-------------|------|---------|:--------:|
 | <a name="input_account_map"></a> [account\_map](#input\_account\_map) | Static account map configuration. Only used when `account_map_enabled` is `false`.<br/>Map keys use `tenant-stage` format (e.g., `core-security`, `core-audit`, `plat-prod`). | <pre>object({<br/>    full_account_map              = map(string)<br/>    audit_account_account_name    = optional(string, "")<br/>    root_account_account_name     = optional(string, "")<br/>    identity_account_account_name = optional(string, "")<br/>    aws_partition                 = optional(string, "aws")<br/>    iam_role_arn_templates        = optional(map(string), {})<br/>  })</pre> | <pre>{<br/>  "audit_account_account_name": "",<br/>  "aws_partition": "aws",<br/>  "full_account_map": {},<br/>  "iam_role_arn_templates": {},<br/>  "identity_account_account_name": "",<br/>  "root_account_account_name": ""<br/>}</pre> | no |
 | <a name="input_account_map_component_name"></a> [account\_map\_component\_name](#input\_account\_map\_component\_name) | The name of the account-map component | `string` | `"account-map"` | no |
-| <a name="input_account_map_enabled"></a> [account\_map\_enabled](#input\_account\_map\_enabled) | Enable the account map component. When true (default), the component fetches account mappings from the<br/>`account-map` component via remote state. When false, the component uses the static `account_map` variable instead. | `bool` | `true` | no |
+| <a name="input_account_map_enabled"></a> [account\_map\_enabled](#input\_account\_map\_enabled) | Enable the account map component. When true, the component fetches account mappings from the<br/>`account-map` component via remote state. When false (default), the component uses the static `account_map` variable instead. | `bool` | `false` | no |
 | <a name="input_account_map_tenant"></a> [account\_map\_tenant](#input\_account\_map\_tenant) | The tenant where the `account_map` component required by remote-state is deployed | `string` | `"core"` | no |
 | <a name="input_account_verification_enabled"></a> [account\_verification\_enabled](#input\_account\_verification\_enabled) | Enable account verification. When true (default), the component verifies that Terraform is executing<br/>in the correct AWS account by comparing the current account ID against the expected account from the<br/>account\_map based on the component's tenant-stage context. | `bool` | `true` | no |
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br/>This is for some rare cases where resources want additional configuration of tags<br/>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
@@ -370,8 +369,6 @@ aws shield describe-subscription
 | <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | <a name="input_global_environment"></a> [global\_environment](#input\_global\_environment) | Global environment name | `string` | `"gbl"` | no |
 | <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br/>Set to `0` for unlimited length.<br/>Set to `null` for keep the existing setting, which defaults to `0`.<br/>Does not affect `id_full`. | `number` | `null` | no |
-| <a name="input_import_profile_name"></a> [import\_profile\_name](#input\_import\_profile\_name) | AWS Profile name to use when importing a resource | `string` | `null` | no |
-| <a name="input_import_role_arn"></a> [import\_role\_arn](#input\_import\_role\_arn) | IAM Role ARN to use when importing a resource | `string` | `null` | no |
 | <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | Controls the letter case of the `tags` keys (label names) for tags generated by this module.<br/>Does not affect keys of tags passed in via the `tags` input.<br/>Possible values: `lower`, `title`, `upper`.<br/>Default value: `title`. | `string` | `null` | no |
 | <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The order in which the labels (ID elements) appear in the `id`.<br/>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br/>You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present. | `list(string)` | `null` | no |
 | <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | Controls the letter case of ID elements (labels) as included in `id`,<br/>set as tag values, and output by this module individually.<br/>Does not affect values of tags passed in via the `tags` input.<br/>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br/>Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.<br/>Default value: `lower`. | `string` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ aws shield describe-subscription
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0.0 |
 
 ## Providers

--- a/README.yaml
+++ b/README.yaml
@@ -34,7 +34,7 @@ description: |-
   - **Auto-Discovery**: Automatically discovers ALB names from EKS ALB controller via remote state
   - **Global and Regional**: Supports both global (Route53, CloudFront) and regional (ALB, EIP) resource protection
   - **Account Verification**: Optional safety check that validates Terraform is running in the correct AWS account
-  - **Flexible Account Map**: Supports both remote-state account-map lookups (default) and static account map variables
+  - **Flexible Account Map**: Supports both remote-state account-map lookups and static account map variables (default)
 
   ## Prerequisites
 

--- a/README.yaml
+++ b/README.yaml
@@ -28,6 +28,14 @@ description: |-
 
   This component configures **AWS Shield Advanced** protection for specific resources.
 
+  ## Component Features
+
+  - **Multi-Resource Protection**: Protects ALBs, CloudFront Distributions, Elastic IPs, and Route53 Hosted Zones
+  - **Auto-Discovery**: Automatically discovers ALB names from EKS ALB controller via remote state
+  - **Global and Regional**: Supports both global (Route53, CloudFront) and regional (ALB, EIP) resource protection
+  - **Account Verification**: Optional safety check that validates Terraform is running in the correct AWS account
+  - **Flexible Account Map**: Supports both remote-state account-map lookups (default) and static account map variables
+
   ## Prerequisites
 
   This component requires that the account where it is being provisioned has been

--- a/src/README.md
+++ b/src/README.md
@@ -5,7 +5,7 @@ tags:
   - provider/aws
 ---
 
-# Component: `shield`
+# Component: `aws-shield`
 
 This component is responsible for enabling AWS Shield Advanced Protection for the following resources:
 
@@ -269,6 +269,7 @@ aws shield describe-subscription
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0.0 |
+| <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules
 
@@ -283,11 +284,11 @@ aws shield describe-subscription
 
 | Name | Type |
 |------|------|
-| [terraform_data.account_verification](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [aws_shield_protection.alb_shield_protection](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/shield_protection) | resource |
 | [aws_shield_protection.cloudfront_shield_protection](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/shield_protection) | resource |
 | [aws_shield_protection.eip_shield_protection](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/shield_protection) | resource |
 | [aws_shield_protection.route53_zone_protection](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/shield_protection) | resource |
+| [terraform_data.account_verification](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [aws_alb.alb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/alb) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_cloudfront_distribution.cloudfront_distribution](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudfront_distribution) | data source |
@@ -299,11 +300,11 @@ aws shield describe-subscription
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_account_map"></a> [account\_map](#input\_account\_map) | Static account map configuration. Only used when `account_map_enabled` is `false`.<br/>Map keys use `tenant-stage` format (e.g., `core-security`, `core-audit`, `plat-prod`). | <pre>object({<br/>  full_account_map              = map(string)<br/>  audit_account_account_name    = optional(string, "")<br/>  root_account_account_name     = optional(string, "")<br/>  identity_account_account_name = optional(string, "")<br/>  aws_partition                 = optional(string, "aws")<br/>  iam_role_arn_templates        = optional(map(string), {})<br/>})</pre> | <pre>{<br/>  "full_account_map": {},<br/>  "audit_account_account_name": "",<br/>  "root_account_account_name": "",<br/>  "identity_account_account_name": "",<br/>  "aws_partition": "aws",<br/>  "iam_role_arn_templates": {}<br/>}</pre> | no |
+| <a name="input_account_map"></a> [account\_map](#input\_account\_map) | Static account map configuration. Only used when `account_map_enabled` is `false`.<br/>Map keys use `tenant-stage` format (e.g., `core-security`, `core-audit`, `plat-prod`). | <pre>object({<br/>    full_account_map              = map(string)<br/>    audit_account_account_name    = optional(string, "")<br/>    root_account_account_name     = optional(string, "")<br/>    identity_account_account_name = optional(string, "")<br/>    aws_partition                 = optional(string, "aws")<br/>    iam_role_arn_templates        = optional(map(string), {})<br/>  })</pre> | <pre>{<br/>  "audit_account_account_name": "",<br/>  "aws_partition": "aws",<br/>  "full_account_map": {},<br/>  "iam_role_arn_templates": {},<br/>  "identity_account_account_name": "",<br/>  "root_account_account_name": ""<br/>}</pre> | no |
 | <a name="input_account_map_component_name"></a> [account\_map\_component\_name](#input\_account\_map\_component\_name) | The name of the account-map component | `string` | `"account-map"` | no |
-| <a name="input_account_map_enabled"></a> [account\_map\_enabled](#input\_account\_map\_enabled) | Enable the account map component. When true (default), the component fetches account mappings from the `account-map` component via remote state. When false, the component uses the static `account_map` variable instead. | `bool` | `true` | no |
+| <a name="input_account_map_enabled"></a> [account\_map\_enabled](#input\_account\_map\_enabled) | Enable the account map component. When true (default), the component fetches account mappings from the<br/>`account-map` component via remote state. When false, the component uses the static `account_map` variable instead. | `bool` | `true` | no |
 | <a name="input_account_map_tenant"></a> [account\_map\_tenant](#input\_account\_map\_tenant) | The tenant where the `account_map` component required by remote-state is deployed | `string` | `"core"` | no |
-| <a name="input_account_verification_enabled"></a> [account\_verification\_enabled](#input\_account\_verification\_enabled) | Enable account verification. When true (default), the component verifies that Terraform is executing in the correct AWS account by comparing the current account ID against the expected account from the account\_map based on the component's tenant-stage context. | `bool` | `true` | no |
+| <a name="input_account_verification_enabled"></a> [account\_verification\_enabled](#input\_account\_verification\_enabled) | Enable account verification. When true (default), the component verifies that Terraform is executing<br/>in the correct AWS account by comparing the current account ID against the expected account from the<br/>account\_map based on the component's tenant-stage context. | `bool` | `true` | no |
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br/>This is for some rare cases where resources want additional configuration of tags<br/>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
 | <a name="input_alb_names"></a> [alb\_names](#input\_alb\_names) | list of ALB names which will be protected with AWS Shield Advanced | `list(string)` | `[]` | no |
 | <a name="input_alb_protection_enabled"></a> [alb\_protection\_enabled](#input\_alb\_protection\_enabled) | Enable ALB protection. By default, ALB names are read from the EKS cluster ALB control group | `bool` | `false` | no |
@@ -317,6 +318,8 @@ aws shield describe-subscription
 | <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | <a name="input_global_environment"></a> [global\_environment](#input\_global\_environment) | Global environment name | `string` | `"gbl"` | no |
 | <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br/>Set to `0` for unlimited length.<br/>Set to `null` for keep the existing setting, which defaults to `0`.<br/>Does not affect `id_full`. | `number` | `null` | no |
+| <a name="input_import_profile_name"></a> [import\_profile\_name](#input\_import\_profile\_name) | AWS Profile name to use when importing a resource | `string` | `null` | no |
+| <a name="input_import_role_arn"></a> [import\_role\_arn](#input\_import\_role\_arn) | IAM Role ARN to use when importing a resource | `string` | `null` | no |
 | <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | Controls the letter case of the `tags` keys (label names) for tags generated by this module.<br/>Does not affect keys of tags passed in via the `tags` input.<br/>Possible values: `lower`, `title`, `upper`.<br/>Default value: `title`. | `string` | `null` | no |
 | <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The order in which the labels (ID elements) appear in the `id`.<br/>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br/>You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present. | `list(string)` | `null` | no |
 | <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | Controls the letter case of ID elements (labels) as included in `id`,<br/>set as tag values, and output by this module individually.<br/>Does not affect values of tags passed in via the `tags` input.<br/>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br/>Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.<br/>Default value: `lower`. | `string` | `null` | no |
@@ -326,7 +329,7 @@ aws shield describe-subscription
 | <a name="input_privileged"></a> [privileged](#input\_privileged) | true if the default provider already has access to the backend | `bool` | `false` | no |
 | <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br/>Characters matching the regex will be removed from the ID elements.<br/>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS Region | `string` | n/a | yes |
-| <a name="input_root_account_stage"></a> [root\_account\_stage](#input\_root\_account\_stage) | The stage name for the Organization root (management) account. This is used to lookup account IDs from account names using the `account-map` component. | `string` | `"root"` | no |
+| <a name="input_root_account_stage"></a> [root\_account\_stage](#input\_root\_account\_stage) | The stage name for the Organization root (management) account. This is used to lookup account IDs from account names<br/>using the `account-map` component. | `string` | `"root"` | no |
 | <a name="input_route53_zone_names"></a> [route53\_zone\_names](#input\_route53\_zone\_names) | List of Route53 Hosted Zone names which will be protected with AWS Shield Advanced | `list(string)` | `[]` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br/>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |

--- a/src/README.md
+++ b/src/README.md
@@ -32,6 +32,14 @@ AWS Shield is a managed DDoS (Distributed Denial of Service) protection service 
 
 This component configures **AWS Shield Advanced** protection for specific resources.
 
+## Component Features
+
+- **Multi-Resource Protection**: Protects ALBs, CloudFront Distributions, Elastic IPs, and Route53 Hosted Zones
+- **Auto-Discovery**: Automatically discovers ALB names from EKS ALB controller via remote state
+- **Global and Regional**: Supports both global (Route53, CloudFront) and regional (ALB, EIP) resource protection
+- **Account Verification**: Optional safety check that validates Terraform is running in the correct AWS account
+- **Flexible Account Map**: Supports both remote-state account-map lookups (default) and static account map variables
+
 ## Prerequisites
 
 This component requires that the account where it is being provisioned has been
@@ -254,18 +262,19 @@ aws shield describe-subscription
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_account_map"></a> [account\_map](#module\_account\_map) | cloudposse/stack-config/yaml//modules/remote-state | 1.8.0 |
 | <a name="module_alb"></a> [alb](#module\_alb) | cloudposse/stack-config/yaml//modules/remote-state | 1.8.0 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
@@ -274,6 +283,7 @@ aws shield describe-subscription
 
 | Name | Type |
 |------|------|
+| [terraform_data.account_verification](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [aws_shield_protection.alb_shield_protection](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/shield_protection) | resource |
 | [aws_shield_protection.cloudfront_shield_protection](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/shield_protection) | resource |
 | [aws_shield_protection.eip_shield_protection](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/shield_protection) | resource |
@@ -289,6 +299,11 @@ aws shield describe-subscription
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_account_map"></a> [account\_map](#input\_account\_map) | Static account map configuration. Only used when `account_map_enabled` is `false`.<br/>Map keys use `tenant-stage` format (e.g., `core-security`, `core-audit`, `plat-prod`). | <pre>object({<br/>  full_account_map              = map(string)<br/>  audit_account_account_name    = optional(string, "")<br/>  root_account_account_name     = optional(string, "")<br/>  identity_account_account_name = optional(string, "")<br/>  aws_partition                 = optional(string, "aws")<br/>  iam_role_arn_templates        = optional(map(string), {})<br/>})</pre> | <pre>{<br/>  "full_account_map": {},<br/>  "audit_account_account_name": "",<br/>  "root_account_account_name": "",<br/>  "identity_account_account_name": "",<br/>  "aws_partition": "aws",<br/>  "iam_role_arn_templates": {}<br/>}</pre> | no |
+| <a name="input_account_map_component_name"></a> [account\_map\_component\_name](#input\_account\_map\_component\_name) | The name of the account-map component | `string` | `"account-map"` | no |
+| <a name="input_account_map_enabled"></a> [account\_map\_enabled](#input\_account\_map\_enabled) | Enable the account map component. When true (default), the component fetches account mappings from the `account-map` component via remote state. When false, the component uses the static `account_map` variable instead. | `bool` | `true` | no |
+| <a name="input_account_map_tenant"></a> [account\_map\_tenant](#input\_account\_map\_tenant) | The tenant where the `account_map` component required by remote-state is deployed | `string` | `"core"` | no |
+| <a name="input_account_verification_enabled"></a> [account\_verification\_enabled](#input\_account\_verification\_enabled) | Enable account verification. When true (default), the component verifies that Terraform is executing in the correct AWS account by comparing the current account ID against the expected account from the account\_map based on the component's tenant-stage context. | `bool` | `true` | no |
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br/>This is for some rare cases where resources want additional configuration of tags<br/>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
 | <a name="input_alb_names"></a> [alb\_names](#input\_alb\_names) | list of ALB names which will be protected with AWS Shield Advanced | `list(string)` | `[]` | no |
 | <a name="input_alb_protection_enabled"></a> [alb\_protection\_enabled](#input\_alb\_protection\_enabled) | Enable ALB protection. By default, ALB names are read from the EKS cluster ALB control group | `bool` | `false` | no |
@@ -300,6 +315,7 @@ aws shield describe-subscription
 | <a name="input_eips"></a> [eips](#input\_eips) | List of Elastic IPs which will be protected with AWS Shield Advanced | `list(string)` | `[]` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
+| <a name="input_global_environment"></a> [global\_environment](#input\_global\_environment) | Global environment name | `string` | `"gbl"` | no |
 | <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br/>Set to `0` for unlimited length.<br/>Set to `null` for keep the existing setting, which defaults to `0`.<br/>Does not affect `id_full`. | `number` | `null` | no |
 | <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | Controls the letter case of the `tags` keys (label names) for tags generated by this module.<br/>Does not affect keys of tags passed in via the `tags` input.<br/>Possible values: `lower`, `title`, `upper`.<br/>Default value: `title`. | `string` | `null` | no |
 | <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The order in which the labels (ID elements) appear in the `id`.<br/>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br/>You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present. | `list(string)` | `null` | no |
@@ -307,8 +323,10 @@ aws shield describe-subscription
 | <a name="input_labels_as_tags"></a> [labels\_as\_tags](#input\_labels\_as\_tags) | Set of labels (ID elements) to include as tags in the `tags` output.<br/>Default is to include all labels.<br/>Tags with empty values will not be included in the `tags` output.<br/>Set to `[]` to suppress all generated tags.<br/>**Notes:**<br/>  The value of the `name` tag, if included, will be the `id`, not the `name`.<br/>  Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be<br/>  changed in later chained modules. Attempts to change it will be silently ignored. | `set(string)` | <pre>[<br/>  "default"<br/>]</pre> | no |
 | <a name="input_name"></a> [name](#input\_name) | ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.<br/>This is the only ID element not also included as a `tag`.<br/>The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input. | `string` | `null` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique | `string` | `null` | no |
+| <a name="input_privileged"></a> [privileged](#input\_privileged) | true if the default provider already has access to the backend | `bool` | `false` | no |
 | <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br/>Characters matching the regex will be removed from the ID elements.<br/>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS Region | `string` | n/a | yes |
+| <a name="input_root_account_stage"></a> [root\_account\_stage](#input\_root\_account\_stage) | The stage name for the Organization root (management) account. This is used to lookup account IDs from account names using the `account-map` component. | `string` | `"root"` | no |
 | <a name="input_route53_zone_names"></a> [route53\_zone\_names](#input\_route53\_zone\_names) | List of Route53 Hosted Zone names which will be protected with AWS Shield Advanced | `list(string)` | `[]` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br/>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |

--- a/src/README.md
+++ b/src/README.md
@@ -5,7 +5,7 @@ tags:
   - provider/aws
 ---
 
-# Component: `aws-shield`
+# Component: `shield`
 
 This component is responsible for enabling AWS Shield Advanced Protection for the following resources:
 
@@ -38,7 +38,7 @@ This component configures **AWS Shield Advanced** protection for specific resour
 - **Auto-Discovery**: Automatically discovers ALB names from EKS ALB controller via remote state
 - **Global and Regional**: Supports both global (Route53, CloudFront) and regional (ALB, EIP) resource protection
 - **Account Verification**: Optional safety check that validates Terraform is running in the correct AWS account
-- **Flexible Account Map**: Supports both remote-state account-map lookups (default) and static account map variables
+- **Flexible Account Map**: Supports both remote-state account-map lookups and static account map variables (default)
 
 ## Prerequisites
 
@@ -277,7 +277,6 @@ aws shield describe-subscription
 |------|--------|---------|
 | <a name="module_account_map"></a> [account\_map](#module\_account\_map) | cloudposse/stack-config/yaml//modules/remote-state | 1.8.0 |
 | <a name="module_alb"></a> [alb](#module\_alb) | cloudposse/stack-config/yaml//modules/remote-state | 1.8.0 |
-| <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
 ## Resources
@@ -302,7 +301,7 @@ aws shield describe-subscription
 |------|-------------|------|---------|:--------:|
 | <a name="input_account_map"></a> [account\_map](#input\_account\_map) | Static account map configuration. Only used when `account_map_enabled` is `false`.<br/>Map keys use `tenant-stage` format (e.g., `core-security`, `core-audit`, `plat-prod`). | <pre>object({<br/>    full_account_map              = map(string)<br/>    audit_account_account_name    = optional(string, "")<br/>    root_account_account_name     = optional(string, "")<br/>    identity_account_account_name = optional(string, "")<br/>    aws_partition                 = optional(string, "aws")<br/>    iam_role_arn_templates        = optional(map(string), {})<br/>  })</pre> | <pre>{<br/>  "audit_account_account_name": "",<br/>  "aws_partition": "aws",<br/>  "full_account_map": {},<br/>  "iam_role_arn_templates": {},<br/>  "identity_account_account_name": "",<br/>  "root_account_account_name": ""<br/>}</pre> | no |
 | <a name="input_account_map_component_name"></a> [account\_map\_component\_name](#input\_account\_map\_component\_name) | The name of the account-map component | `string` | `"account-map"` | no |
-| <a name="input_account_map_enabled"></a> [account\_map\_enabled](#input\_account\_map\_enabled) | Enable the account map component. When true (default), the component fetches account mappings from the<br/>`account-map` component via remote state. When false, the component uses the static `account_map` variable instead. | `bool` | `true` | no |
+| <a name="input_account_map_enabled"></a> [account\_map\_enabled](#input\_account\_map\_enabled) | Enable the account map component. When true, the component fetches account mappings from the<br/>`account-map` component via remote state. When false (default), the component uses the static `account_map` variable instead. | `bool` | `false` | no |
 | <a name="input_account_map_tenant"></a> [account\_map\_tenant](#input\_account\_map\_tenant) | The tenant where the `account_map` component required by remote-state is deployed | `string` | `"core"` | no |
 | <a name="input_account_verification_enabled"></a> [account\_verification\_enabled](#input\_account\_verification\_enabled) | Enable account verification. When true (default), the component verifies that Terraform is executing<br/>in the correct AWS account by comparing the current account ID against the expected account from the<br/>account\_map based on the component's tenant-stage context. | `bool` | `true` | no |
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br/>This is for some rare cases where resources want additional configuration of tags<br/>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
@@ -318,8 +317,6 @@ aws shield describe-subscription
 | <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | <a name="input_global_environment"></a> [global\_environment](#input\_global\_environment) | Global environment name | `string` | `"gbl"` | no |
 | <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br/>Set to `0` for unlimited length.<br/>Set to `null` for keep the existing setting, which defaults to `0`.<br/>Does not affect `id_full`. | `number` | `null` | no |
-| <a name="input_import_profile_name"></a> [import\_profile\_name](#input\_import\_profile\_name) | AWS Profile name to use when importing a resource | `string` | `null` | no |
-| <a name="input_import_role_arn"></a> [import\_role\_arn](#input\_import\_role\_arn) | IAM Role ARN to use when importing a resource | `string` | `null` | no |
 | <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | Controls the letter case of the `tags` keys (label names) for tags generated by this module.<br/>Does not affect keys of tags passed in via the `tags` input.<br/>Possible values: `lower`, `title`, `upper`.<br/>Default value: `title`. | `string` | `null` | no |
 | <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The order in which the labels (ID elements) appear in the `id`.<br/>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br/>You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present. | `list(string)` | `null` | no |
 | <a name="input_label_value_case"></a> [label\_value\_case](#input\_label\_value\_case) | Controls the letter case of ID elements (labels) as included in `id`,<br/>set as tag values, and output by this module individually.<br/>Does not affect values of tags passed in via the `tags` input.<br/>Possible values: `lower`, `title`, `upper` and `none` (no transformation).<br/>Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.<br/>Default value: `lower`. | `string` | `null` | no |

--- a/src/README.md
+++ b/src/README.md
@@ -261,7 +261,7 @@ aws shield describe-subscription
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0.0 |
 
 ## Providers

--- a/src/account-verification.tf
+++ b/src/account-verification.tf
@@ -1,0 +1,63 @@
+# Account Verification
+#
+# Verifies that Terraform is executing in the correct target AWS account by comparing the current
+# AWS account ID against the expected account ID based on the component's context (tenant-stage).
+#
+# How it works:
+# 1. Constructs the expected account name from context variables (format: "tenant-stage")
+# 2. Looks up the expected account ID from the account_map
+# 3. Validates that current account ID matches expected account ID
+# 4. Fails with a clear error message if accounts don't match
+#
+# Note: Validation only occurs when account_verification_enabled is true, the account_map is
+# populated, and the expected account name can be constructed from tenant and stage variables.
+
+locals {
+  # Construct expected account name in the format "tenant-stage".
+  # Only construct if both tenant and stage are non-null and non-empty strings.
+  expected_account_name = (
+    var.account_verification_enabled &&
+    try(var.tenant, null) != null &&
+    try(var.stage, null) != null &&
+    try(var.tenant, "") != "" &&
+    try(var.stage, "") != ""
+  ) ? "${var.tenant}-${var.stage}" : null
+
+  # Look up the expected account ID from account_map using the expected account name.
+  # Returns null if account name cannot be constructed or if the name is not found in the map.
+  expected_account_id = try(
+    local.expected_account_name != null ? local.account_map[local.expected_account_name] : null,
+    null
+  )
+
+  # Determine if validation should be performed based on:
+  # 1. account_verification_enabled is true
+  # 2. account_map is provided and not empty
+  # 3. Expected account name can be constructed from tenant and stage
+  # 4. Expected account ID exists in the account_map for the constructed account name
+  should_verify_account = (
+    var.account_verification_enabled &&
+    length(local.account_map) > 0 &&
+    local.expected_account_name != null &&
+    local.expected_account_id != null
+  )
+
+  # Error message for account mismatch.
+  account_verification_error = local.should_verify_account && local.current_account_id != local.expected_account_id ? (
+    "Account verification failed: Expected account ID ${local.expected_account_id} for account '${local.expected_account_name}' (tenant: ${var.tenant}, stage: ${var.stage}), but current account ID is ${local.current_account_id}"
+  ) : "Account verification passed"
+}
+
+# Perform account verification using terraform_data resource with lifecycle precondition.
+# The precondition ensures that the current account ID matches the expected account ID,
+# failing the Terraform run with a descriptive error if there's a mismatch.
+resource "terraform_data" "account_verification" {
+  count = local.should_verify_account ? 1 : 0
+
+  lifecycle {
+    precondition {
+      condition     = local.current_account_id == local.expected_account_id
+      error_message = local.account_verification_error
+    }
+  }
+}

--- a/src/account-verification.tf
+++ b/src/account-verification.tf
@@ -36,6 +36,7 @@ locals {
   # 3. Expected account name can be constructed from tenant and stage
   # 4. Expected account ID exists in the account_map for the constructed account name
   should_verify_account = (
+    local.enabled &&
     var.account_verification_enabled &&
     length(local.account_map) > 0 &&
     local.expected_account_name != null &&

--- a/src/main.tf
+++ b/src/main.tf
@@ -1,8 +1,10 @@
 locals {
-  enabled = module.this.enabled
-  tags    = module.this.tags
+  enabled     = module.this.enabled
+  tags        = module.this.tags
+  account_map = module.account_map.outputs.full_account_map
 
-  account_id = one(data.aws_caller_identity.current[*].account_id)
+  account_id         = one(data.aws_caller_identity.current[*].account_id)
+  current_account_id = local.account_id
 
   # Used to determine correct partition (i.e. - `aws`, `aws-gov`, `aws-cn`, etc.)
   partition = one(data.aws_partition.current[*].partition)

--- a/src/providers.tf
+++ b/src/providers.tf
@@ -1,31 +1,3 @@
 provider "aws" {
   region = var.region
-
-  # When account_map_enabled is false, provider auth is handled externally (e.g., by Atmos)
-  profile = var.account_map_enabled && !var.privileged && module.iam_roles.profiles_enabled ? coalesce(var.import_profile_name, module.iam_roles.terraform_profile_name) : null
-  dynamic "assume_role" {
-    for_each = !var.account_map_enabled || var.privileged || module.iam_roles.profiles_enabled ? [] : ["role"]
-    content {
-      role_arn = coalesce(var.import_role_arn, module.iam_roles.terraform_role_arn)
-    }
-  }
-}
-
-module "iam_roles" {
-  source     = "../account-map/modules/iam-roles"
-  privileged = var.privileged
-
-  context = module.this.context
-}
-
-variable "import_profile_name" {
-  type        = string
-  default     = null
-  description = "AWS Profile name to use when importing a resource"
-}
-
-variable "import_role_arn" {
-  type        = string
-  default     = null
-  description = "IAM Role ARN to use when importing a resource"
 }

--- a/src/providers.tf
+++ b/src/providers.tf
@@ -1,19 +1,31 @@
 provider "aws" {
   region = var.region
 
-  # Profile is deprecated in favor of terraform_role_arn. When profiles are not in use, terraform_profile_name is null.
-  profile = module.iam_roles.terraform_profile_name
-
+  # When account_map_enabled is false, provider auth is handled externally (e.g., by Atmos)
+  profile = var.account_map_enabled && !var.privileged && module.iam_roles.profiles_enabled ? coalesce(var.import_profile_name, module.iam_roles.terraform_profile_name) : null
   dynamic "assume_role" {
-    # module.iam_roles.terraform_role_arn may be null, in which case do not assume a role.
-    for_each = compact([module.iam_roles.terraform_role_arn])
+    for_each = !var.account_map_enabled || var.privileged || module.iam_roles.profiles_enabled ? [] : ["role"]
     content {
-      role_arn = assume_role.value
+      role_arn = coalesce(var.import_role_arn, module.iam_roles.terraform_role_arn)
     }
   }
 }
 
 module "iam_roles" {
-  source  = "../account-map/modules/iam-roles"
+  source     = "../account-map/modules/iam-roles"
+  privileged = var.privileged
+
   context = module.this.context
+}
+
+variable "import_profile_name" {
+  type        = string
+  default     = null
+  description = "AWS Profile name to use when importing a resource"
+}
+
+variable "import_role_arn" {
+  type        = string
+  default     = null
+  description = "IAM Role ARN to use when importing a resource"
 }

--- a/src/remote-state.tf
+++ b/src/remote-state.tf
@@ -1,3 +1,19 @@
+module "account_map" {
+  source  = "cloudposse/stack-config/yaml//modules/remote-state"
+  version = "1.8.0"
+
+  component   = var.account_map_component_name
+  tenant      = var.account_map_enabled ? coalesce(var.account_map_tenant, module.this.tenant) : null
+  stage       = var.account_map_enabled ? var.root_account_stage : null
+  environment = var.account_map_enabled ? var.global_environment : null
+  privileged  = var.privileged
+
+  context = module.this.context
+
+  bypass   = !var.account_map_enabled
+  defaults = var.account_map
+}
+
 module "alb" {
   count   = local.alb_protection_enabled == false ? 0 : length(var.alb_names) > 0 ? 0 : 1
   source  = "cloudposse/stack-config/yaml//modules/remote-state"

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -11,10 +11,10 @@ variable "account_verification_enabled" {
 variable "account_map_enabled" {
   type        = bool
   description = <<-DOC
-  Enable the account map component. When true (default), the component fetches account mappings from the
-  `account-map` component via remote state. When false, the component uses the static `account_map` variable instead.
+  Enable the account map component. When true, the component fetches account mappings from the
+  `account-map` component via remote state. When false (default), the component uses the static `account_map` variable instead.
   DOC
-  default     = true
+  default     = false
 }
 
 variable "account_map" {

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -1,6 +1,81 @@
+variable "account_verification_enabled" {
+  type        = bool
+  description = <<-DOC
+  Enable account verification. When true (default), the component verifies that Terraform is executing
+  in the correct AWS account by comparing the current account ID against the expected account from the
+  account_map based on the component's tenant-stage context.
+  DOC
+  default     = true
+}
+
+variable "account_map_enabled" {
+  type        = bool
+  description = <<-DOC
+  Enable the account map component. When true (default), the component fetches account mappings from the
+  `account-map` component via remote state. When false, the component uses the static `account_map` variable instead.
+  DOC
+  default     = true
+}
+
+variable "account_map" {
+  type = object({
+    full_account_map              = map(string)
+    audit_account_account_name    = optional(string, "")
+    root_account_account_name     = optional(string, "")
+    identity_account_account_name = optional(string, "")
+    aws_partition                 = optional(string, "aws")
+    iam_role_arn_templates        = optional(map(string), {})
+  })
+  description = <<-DOC
+  Static account map configuration. Only used when `account_map_enabled` is `false`.
+  Map keys use `tenant-stage` format (e.g., `core-security`, `core-audit`, `plat-prod`).
+  DOC
+  default = {
+    full_account_map              = {}
+    audit_account_account_name    = ""
+    root_account_account_name     = ""
+    identity_account_account_name = ""
+    aws_partition                 = "aws"
+    iam_role_arn_templates        = {}
+  }
+}
+
+variable "account_map_component_name" {
+  type        = string
+  description = "The name of the account-map component"
+  default     = "account-map"
+}
+
+variable "account_map_tenant" {
+  type        = string
+  default     = "core"
+  description = "The tenant where the `account_map` component required by remote-state is deployed"
+}
+
+variable "global_environment" {
+  type        = string
+  default     = "gbl"
+  description = "Global environment name"
+}
+
+variable "privileged" {
+  type        = bool
+  default     = false
+  description = "true if the default provider already has access to the backend"
+}
+
 variable "region" {
   type        = string
   description = "AWS Region"
+}
+
+variable "root_account_stage" {
+  type        = string
+  default     = "root"
+  description = <<-DOC
+  The stage name for the Organization root (management) account. This is used to lookup account IDs from account names
+  using the `account-map` component.
+  DOC
 }
 
 variable "alb_names" {

--- a/src/versions.tf
+++ b/src/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.4.0"
 
   required_providers {
     aws = {

--- a/src/versions.tf
+++ b/src/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0"
+      version = ">= 5.0.0"
     }
   }
 }


### PR DESCRIPTION
## what

- Added account verification safety check (`account-verification.tf`) with `local.enabled` guard to prevent verification from running on disabled components
- Added flexible account map support with both remote-state lookups and static `account_map` variable (default)
- Simplified `providers.tf` to use static account map by default
- Bumped Terraform `required_version` from `>= 1.0.0` to `>= 1.4.0` (required for `terraform_data` resource used by account verification)
- Updated `README.yaml` and regenerated all READMEs with:
  - Account verification documentation
  - Static vs remote-state account map modes
  - Shield Advanced protection for ALBs, CloudFront, EIPs, Route53

## why

- Account verification prevents accidental deployment to wrong AWS accounts — the `local.enabled` guard ensures it doesn't trigger false failures on disabled components
- Terraform 1.4.0+ is required for the `terraform_data` resource used by account verification
- Static account map default simplifies initial setup and aligns with the pattern used across other security components (`aws-audit-manager`, `aws-inspector2`, `aws-access-analyzer`, `aws-security-hub`, `aws-config`, `aws-guardduty`, `aws-macie`)
- These changes have been validated in a live AWS Organization deployment

## references

- [AWS Shield Documentation](https://docs.aws.amazon.com/waf/latest/developerguide/shield-chapter.html)
- [Shield Advanced Protection](https://docs.aws.amazon.com/waf/latest/developerguide/ddos-advanced-summary.html)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added account verification to validate correct AWS account deployment.
  * Introduced flexible account mapping with remote-state and static map support.
  * Added auto-discovery capability for resource names via remote state.

* **Requirements**
  * Updated minimum Terraform version to 1.4.0 and AWS provider to 5.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->