### PR TITLE
chore: migrate Renovate preset to recommended

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "prConcurrentLimit": 5,
   "extends": [
-    "config:base"
+    "config:recommended"
   ]
 }


### PR DESCRIPTION
## Summary
- Migrates Renovate from the deprecated `config:base` preset to `config:recommended`.
- Keeps the existing `prConcurrentLimit` unchanged.

## Verification
- `python3 -m json.tool .github/renovate.json`
- `git diff --check`

Note: I did not run the normal Atmos/Terratest suite because this repository's guidance indicates those tests can deploy AWS resources and require credentials.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management automation configuration to apply enhanced update handling rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->